### PR TITLE
Embed JSX syntax in JS and TSReact.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,13 @@
             {
                 "language": "javascript",
                 "scopeName": "source.js",
-                "path": "./syntaxes/JavaScript.tmLanguage.json"
+                "path": "./syntaxes/JavaScript.tmLanguage.json",
+                "embeddedLanguages": {
+                    "meta.tag.js": "jsx-tags",
+                    "meta.tag.without-attributes.js": "jsx-tags",
+                    "meta.tag.attributes.js": "javascript",
+                    "meta.embedded.expression.js": "javascript"
+                }
             },
             {
                 "language": "typescript",
@@ -54,7 +60,13 @@
             {
                 "language": "typescriptreact",
                 "scopeName": "source.tsx",
-                "path": "./syntaxes/TypeScriptReact.tmLanguage.json"
+                "path": "./syntaxes/TypeScriptReact.tmLanguage.json",
+                "embeddedLanguages": {
+                    "meta.tag.tsx": "jsx-tags",
+                    "meta.tag.without-attributes.tsx": "jsx-tags",
+                    "meta.tag.attributes.tsx": "typescriptreact",
+                    "meta.embedded.expression.tsx": "typescriptreact"
+                }
             }
         ]
     }


### PR DESCRIPTION
VS Code wasn't automatically adding indentation within JSX tags while this package was active. After a little amateur sleuthing, I wound up grabbing this from the built-in JavaScript extension:

https://github.com/microsoft/vscode/blob/a848f18df4efa9eb947bd01cbebcede418e66148/extensions/javascript/package.json#L69-L85

It seems to restore the on-enter behavior on my machine, but I can't make too many assurances beyond that---the sleuthing was very amateur indeed.